### PR TITLE
Add Standup Meeting Notes Template

### DIFF
--- a/standup.md
+++ b/standup.md
@@ -26,8 +26,6 @@ What did they speak about?
 Action items:
 - [ ] ...
 
----
-
 ## After the meeting
 
 Key issues for the team:

--- a/standup.md
+++ b/standup.md
@@ -1,0 +1,40 @@
+# Round-Robin Standup Notes Template
+
+## Before the meeting
+
+1. What did I work on yesterday?
+	- ...
+2. What am I working on today?
+ 	- ...
+3. What are my blockers?
+	- ...
+
+## During the meeting
+
+Date: 
+
+Who showed up?
+- Kalkin
+- ...
+
+What did they speak about?
+
+| Name     | Yesterday's Work | Today's Plan    | Blockers       |
+| :------: | :--------------: | :-------------: | :------------: |
+| ...      |                  |                 |                |
+
+Action items:
+- [ ] ...
+
+---
+
+## After the meeting
+
+Key issues for the team:
+- ...
+
+People that can help with my blockers:
+- ...
+
+People who's blockers I can help with:
+- ...

--- a/standup.md
+++ b/standup.md
@@ -34,5 +34,5 @@ Key issues for the team:
 People that can help with my blockers:
 - ...
 
-People who's blockers I can help with:
+People whose blockers I can help with:
 - ...


### PR DESCRIPTION
This is in response to a feature requested in Issue #1. The template is now complete and created using principles from the Atlassian standup guide. Merging this pr would close #1.